### PR TITLE
add source-map-support

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "koa-router": "^10.1.1",
     "lodash": "^4.17.21",
     "mongoose": "6.0.12",
-    "mongoose-findorcreate": "^3.0.0"
+    "mongoose-findorcreate": "^3.0.0",
+    "source-map-support": "^0.5.21"
   },
   "devDependencies": {
     "@typegoose/typegoose": "^9.2.0",

--- a/package.json
+++ b/package.json
@@ -26,8 +26,7 @@
     "koa-router": "^10.1.1",
     "lodash": "^4.17.21",
     "mongoose": "6.0.12",
-    "mongoose-findorcreate": "^3.0.0",
-    "source-map-support": "^0.5.21"
+    "mongoose-findorcreate": "^3.0.0"
   },
   "devDependencies": {
     "@typegoose/typegoose": "^9.2.0",
@@ -54,6 +53,7 @@
     "module-alias": "^2.2.2",
     "mongodb-memory-server": "^8.0.0",
     "prettier": "^2.4.1",
+    "source-map-support": "^0.5.21",
     "supertest": "^6.1.6",
     "ts-jest": "^27.0.7",
     "tsc-watch": "^4.5.0",

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,5 +1,4 @@
 import 'source-map-support/register'
-
 // Setup typegoose
 import { Severity, setGlobalOptions } from '@typegoose/typegoose'
 setGlobalOptions({

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,3 +1,5 @@
+import 'source-map-support/register'
+
 // Setup typegoose
 import { Severity, setGlobalOptions } from '@typegoose/typegoose'
 setGlobalOptions({

--- a/yarn.lock
+++ b/yarn.lock
@@ -1713,6 +1713,7 @@ __metadata:
     mongoose: 6.0.12
     mongoose-findorcreate: ^3.0.0
     prettier: ^2.4.1
+    source-map-support: ^0.5.21
     supertest: ^6.1.6
     ts-jest: ^27.0.7
     tsc-watch: ^4.5.0
@@ -6062,6 +6063,16 @@ __metadata:
     ip: ^1.1.5
     smart-buffer: ^4.1.0
   checksum: 2ca9d616e424f645838ebaabb04f85d94ea999e0f8393dc07f86c435af22ed88cb83958feeabd1bb7bc537c635ed47454255635502c6808a6df61af1f41af750
+  languageName: node
+  linkType: hard
+
+"source-map-support@npm:^0.5.21":
+  version: 0.5.21
+  resolution: "source-map-support@npm:0.5.21"
+  dependencies:
+    buffer-from: ^1.0.0
+    source-map: ^0.6.0
+  checksum: 43e98d700d79af1d36f859bdb7318e601dfc918c7ba2e98456118ebc4c4872b327773e5a1df09b0524e9e5063bb18f0934538eace60cca2710d1fa687645d137
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This module provides source map support for stack traces in node via the V8 stack trace API. It uses the source-map module to replace the paths and line numbers of source-mapped files with their original paths and line numbers